### PR TITLE
[TASK] Move from the deprecated 'getPositionFromMatrix' to the new 'setF...

### DIFF
--- a/threex.objcoord.js
+++ b/threex.objcoord.js
@@ -21,13 +21,13 @@ THREEx.ObjCoord	= function(object3d){
 THREEx.ObjCoord.worldPosition	= function(object3d){
 	object3d.updateMatrixWorld();
 	var worldMatrix	= object3d.matrixWorld;
-	var worldPos	= new THREE.Vector3().getPositionFromMatrix(worldMatrix);
+	var worldPos	= new THREE.Vector3().setFromMatrixPosition(worldMatrix);
 	return worldPos;
 }
 
 /**
  * get screen position
- * 
+ *
  * @param  {THREE.Object3D} object3d	the object3damera used to render
  * @param  {THREE.Camera} camera	the camera used to render
  * @return {THREE.Vector3}			the screen position
@@ -40,7 +40,7 @@ THREEx.ObjCoord.screenPosition	= function(object3d, camera){
 
 /**
  * get css position
- * 
+ *
  * @param  {THREE.Object3D} object3d	the object3damera used to render
  * @param  {THREE.Renderer} renderer	the renderer used to render
  * @param  {THREE.Camera} camera	the camera used to render
@@ -57,7 +57,7 @@ THREEx.ObjCoord.cssPosition	= function(object3d, camera, renderer){
 
 /**
  * convert world position to screen space
- * 
+ *
  * @param  {THREE.Vector3}	worldPosition	the world position
  * @param  {THREE.Camera}	tCamera       	the camera used to render
  * @return {THREE.Vector3}			the screen space position [-1, +1]


### PR DESCRIPTION
...romMatrixPosition' method.

As stated in the console.log warnings of the newest ThreeJS build.
